### PR TITLE
Missing WorldPing logo on the home page in Grafana 6

### DIFF
--- a/src/dashboards/worldping-home.json
+++ b/src/dashboards/worldping-home.json
@@ -15,7 +15,7 @@
         "height": "39px",
         "panels": [
           {
-            "content": "<img src=\"public/plugins/raintank-worldping-app/img/worldPing-grey.svg\" height=\"50\">",
+            "content": "<img src=\"/public/plugins/raintank-worldping-app/img/worldPing-grey.svg\" height=\"50\">",
             "editable": true,
             "error": false,
             "id": 2,


### PR DESCRIPTION
closes https://github.com/raintank/worldping-app/issues/218
Home page now displays the logo:
![image](https://user-images.githubusercontent.com/22073083/54683832-bd194800-4b23-11e9-808b-6186e31424a9.png)
