### PR TITLE
Grafana v6 beta 1 / worldping 1.2.4 : constantly requires a datasource update #215

### DIFF
--- a/src/components/config/dsUpgrade.js
+++ b/src/components/config/dsUpgrade.js
@@ -1,4 +1,4 @@
-import _ from 'lodash' ;
+import _ from 'lodash';
 
 export default class DatasourceUpgrader {
   constructor(contextSrv, backendSrv, $q, datasourceSrv) {
@@ -20,13 +20,17 @@ export default class DatasourceUpgrader {
       return false;
     }
 
-    var datasources = this.datasourceSrv.getAll();
+    const datasources = this.datasourceSrv.getAll();
 
-    if (!datasources.raintank || !/^\/api\/datasources\/proxy/.exec(datasources.raintank.url)) {
+    const raintank = getDatasourceByName(datasources, 'raintank');
+
+    if (!raintank || !/^\/api\/datasources\/proxy/.exec(raintank.url)) {
       return true;
     }
 
-    if (!datasources.raintankEvents || !/^\/api\/datasources\/proxy/.exec(datasources.raintankEvents.url)) {
+    const raintankEvents = getDatasourceByName(datasources, 'raintankEvents');
+
+    if (!raintankEvents || !/^\/api\/datasources\/proxy/.exec(raintankEvents.url)) {
       return true;
     }
 
@@ -168,5 +172,13 @@ export default class DatasourceUpgrader {
         return result;
       });
     });
+  }
+}
+
+function getDatasourceByName(datasources, name) {
+  if (_.isArray(datasources)) {
+    return _.find(datasources, { name });
+  } else {
+    return datasources[name];
   }
 }


### PR DESCRIPTION
Fix for #215

`this.datasourceSrv.getAll()` was expected to return object but it returns array in Grafana 6.x

Before:
![image](https://user-images.githubusercontent.com/1989898/54707481-434c8300-4b52-11e9-8e54-cf3a65d71568.png)

After:
![image](https://user-images.githubusercontent.com/1989898/54707684-b35b0900-4b52-11e9-81c2-71b9db12f859.png)
